### PR TITLE
Get height from label context

### DIFF
--- a/brother_ql_web.py
+++ b/brother_ql_web.py
@@ -163,7 +163,7 @@ def create_label_grocy(text, **kwargs):
     product_font = ImageFont.truetype(kwargs['font_path'], 100)
     duedate_font = ImageFont.truetype(kwargs['font_path'], 60)
     width = kwargs['width']
-    height = 200
+    height = kwargs['height']
     if kwargs['orientation'] == 'rotated':
         tw = width
         width = height


### PR DESCRIPTION
Height is hardcoded to 200 and causes printing to fail on QL-810W with 29x90mm die-cut labels:

`ValueError: Bad image dimensions: (991, 200). Expecting: (306, 991).`

This change gets the height from the context instead.