### PR TITLE
Print a larger label, wrap the text, 

### DIFF
--- a/brother_ql_web.py
+++ b/brother_ql_web.py
@@ -88,7 +88,7 @@ def get_label_context(request):
         "margin_right": float(d.get("margin_right", 35)) / 100.0,
         "grocycode": d.get("grocycode", None),
         "product": d.get("product", None),
-        "duedate": d.get("duedate", None),
+        "duedate": d.get("duedate", d.get("due_date", None)),
     }
     context["margin_top"] = int(context["font_size"] * context["margin_top"])
     context["margin_bottom"] = int(context["font_size"] * context["margin_bottom"])
@@ -210,19 +210,21 @@ def create_label_grocy(text, **kwargs):
 
     title_text = "\n".join(lines)
     grocycode_text = grocycode
-    best_by_text = duedate
+    best_by_text = "Best By: \n" + ("unknown" if duedate is None else duedate)
 
     title_textsize = draw.multiline_textsize(title_text, font=product_font)
-    grocycode_textsize = draw.textsize(
-        grocycode_text, font=code_font
-    )
-    best_by_textsize = draw.textsize(
-        best_by_text, font=best_by_font
-    )
+    grocycode_textsize = draw.textsize(grocycode_text, font=code_font)
+    best_by_textsize = draw.multiline_textsize(best_by_text, font=best_by_font)
 
     # Increase the size of the image to accomodate the text
-    height = kwargs['margin_top'] + title_textsize[1] + grocycode_textsize[1] + encoded.height + kwargs['margin_bottom']
-    newim = Image.new('RGB', (width, height), 'white')
+    height = (
+        kwargs["margin_top"]
+        + title_textsize[1]
+        + grocycode_textsize[1]
+        + encoded.height
+        + kwargs["margin_bottom"]
+    )
+    newim = Image.new("RGB", (width, height), "white")
     draw = ImageDraw.Draw(newim)
     newim.paste(im)
     im = newim
@@ -241,11 +243,16 @@ def create_label_grocy(text, **kwargs):
             vertical_offset + encoded.height,
         ),
     )
-    draw.multiline_text((horizontal_offset + encoded.width, vertical_offset), f"Best By:\n{duedate}", kwargs['fill_color'], font=best_by_font)
+    draw.multiline_text(
+        (horizontal_offset + encoded.width, vertical_offset),
+        best_by_text,
+        kwargs["fill_color"],
+        font=best_by_font,
+    )
     vertical_offset = vertical_offset + encoded.height
     textoffset = horizontal_offset, vertical_offset
 
-    draw.text(textoffset, f"{grocycode}", kwargs['fill_color'], font=code_font)
+    draw.text(textoffset, f"{grocycode}", kwargs["fill_color"], font=code_font)
 
     return im
 
@@ -318,8 +325,8 @@ def print_grocy():
     )
 
     # Uncomment to render the image directly in the browser
-    #response.set_header("Content-type", "image/png")
-    #return image_to_png_bytes(im)
+    # response.set_header("Content-type", "image/png")
+    # return image_to_png_bytes(im)
 
     if not DEBUG:
         try:

--- a/brother_ql_web.py
+++ b/brother_ql_web.py
@@ -353,7 +353,7 @@ def main():
     else:
         LOGLEVEL = CONFIG['SERVER']['LOGLEVEL']
 
-    if LOGLEVEL == 'DEBUG':
+    if LOGLEVEL == 10: # "DEBUG"
         DEBUG = True
     else:
         DEBUG = False

--- a/brother_ql_web.py
+++ b/brother_ql_web.py
@@ -317,8 +317,9 @@ def print_grocy():
         rotate=rotate,
     )
 
-    response.set_header("Content-type", "image/png")
-    return image_to_png_bytes(im)
+    # Uncomment to render the image directly in the browser
+    #response.set_header("Content-type", "image/png")
+    #return image_to_png_bytes(im)
 
     if not DEBUG:
         try:

--- a/brother_ql_web.py
+++ b/brother_ql_web.py
@@ -8,8 +8,19 @@ This is a web service to print labels on Brother QL label printers.
 import sys, logging, random, json, argparse
 from io import BytesIO
 
-from bottle import run, route, get, post, response, request, jinja2_view as view, static_file, redirect
+from bottle import (
+    run,
+    route,
+    get,
+    post,
+    response,
+    request,
+    jinja2_view as view,
+    static_file,
+    redirect,
+)
 from PIL import Image, ImageDraw, ImageFont
+from pylibdmtx.pylibdmtx import encode
 
 from brother_ql.devicedependent import models, label_type_specs, label_sizes
 from brother_ql.devicedependent import ENDLESS_LABEL, DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL
@@ -20,204 +31,240 @@ from font_helpers import get_fonts
 
 logger = logging.getLogger(__name__)
 
-LABEL_SIZES = [ (name, label_type_specs[name]['name']) for name in label_sizes]
+LABEL_SIZES = [(name, label_type_specs[name]["name"]) for name in label_sizes]
 
 try:
-    with open('config.json', encoding='utf-8') as fh:
+    with open("config.json", encoding="utf-8") as fh:
         CONFIG = json.load(fh)
 except FileNotFoundError as e:
-    with open('config.example.json', encoding='utf-8') as fh:
+    with open("config.example.json", encoding="utf-8") as fh:
         CONFIG = json.load(fh)
 
 
-@route('/')
+@route("/")
 def index():
-    redirect('/labeldesigner')
+    redirect("/labeldesigner")
 
-@route('/static/<filename:path>')
+
+@route("/static/<filename:path>")
 def serve_static(filename):
-    return static_file(filename, root='./static')
+    return static_file(filename, root="./static")
 
-@route('/labeldesigner')
-@view('labeldesigner.jinja2')
+
+@route("/labeldesigner")
+@view("labeldesigner.jinja2")
 def labeldesigner():
     font_family_names = sorted(list(FONTS.keys()))
-    return {'font_family_names': font_family_names,
-            'fonts': FONTS,
-            'label_sizes': LABEL_SIZES,
-            'website': CONFIG['WEBSITE'],
-            'label': CONFIG['LABEL']}
+    return {
+        "font_family_names": font_family_names,
+        "fonts": FONTS,
+        "label_sizes": LABEL_SIZES,
+        "website": CONFIG["WEBSITE"],
+        "label": CONFIG["LABEL"],
+    }
+
 
 def get_label_context(request):
     """ might raise LookupError() """
 
-    d = request.params.decode() # UTF-8 decoded form data
+    d = request.params.decode()  # UTF-8 decoded form data
 
-    font_family = d.get('font_family').rpartition('(')[0].strip()
-    font_style  = d.get('font_family').rpartition('(')[2].rstrip(')')
+    font_family = d.get("font_family").rpartition("(")[0].strip()
+    font_style = d.get("font_family").rpartition("(")[2].rstrip(")")
     context = {
-      'text':          d.get('text', None),
-      'font_size': int(d.get('font_size', 100)),
-      'font_family':   font_family,
-      'font_style':    font_style,
-      'label_size':    d.get('label_size', "62"),
-      'kind':          label_type_specs[d.get('label_size', "62")]['kind'],
-      'margin':    int(d.get('margin', 10)),
-      'threshold': int(d.get('threshold', 70)),
-      'align':         d.get('align', 'center'),
-      'orientation':   d.get('orientation', 'standard'),
-      'margin_top':    float(d.get('margin_top',    24))/100.,
-      'margin_bottom': float(d.get('margin_bottom', 45))/100.,
-      'margin_left':   float(d.get('margin_left',   35))/100.,
-      'margin_right':  float(d.get('margin_right',  35))/100.,
-      'grocycode': d.get('grocycode', None),
-      'product': d.get('product', None),
-      'duedate': d.get('duedate', None)
+        "text": d.get("text", None),
+        "font_size": int(d.get("font_size", 100)),
+        "font_family": font_family,
+        "font_style": font_style,
+        "label_size": d.get("label_size", "62"),
+        "kind": label_type_specs[d.get("label_size", "62")]["kind"],
+        "margin": int(d.get("margin", 10)),
+        "threshold": int(d.get("threshold", 70)),
+        "align": d.get("align", "center"),
+        "orientation": d.get("orientation", "standard"),
+        "margin_top": float(d.get("margin_top", 24)) / 100.0,
+        "margin_bottom": float(d.get("margin_bottom", 45)) / 100.0,
+        "margin_left": float(d.get("margin_left", 35)) / 100.0,
+        "margin_right": float(d.get("margin_right", 35)) / 100.0,
+        "grocycode": d.get("grocycode", None),
+        "product": d.get("product", None),
+        "duedate": d.get("duedate", None),
     }
-    context['margin_top']    = int(context['font_size']*context['margin_top'])
-    context['margin_bottom'] = int(context['font_size']*context['margin_bottom'])
-    context['margin_left']   = int(context['font_size']*context['margin_left'])
-    context['margin_right']  = int(context['font_size']*context['margin_right'])
+    context["margin_top"] = int(context["font_size"] * context["margin_top"])
+    context["margin_bottom"] = int(context["font_size"] * context["margin_bottom"])
+    context["margin_left"] = int(context["font_size"] * context["margin_left"])
+    context["margin_right"] = int(context["font_size"] * context["margin_right"])
 
-    context['fill_color']  = (255, 0, 0) if 'red' in context['label_size'] else (0, 0, 0)
+    context["fill_color"] = (255, 0, 0) if "red" in context["label_size"] else (0, 0, 0)
 
     def get_font_path(font_family_name, font_style_name):
         try:
             if font_family_name is None or font_style_name is None:
-                font_family_name = CONFIG['LABEL']['DEFAULT_FONTS']['family']
-                font_style_name =  CONFIG['LABEL']['DEFAULT_FONTS']['style']
+                font_family_name = CONFIG["LABEL"]["DEFAULT_FONTS"]["family"]
+                font_style_name = CONFIG["LABEL"]["DEFAULT_FONTS"]["style"]
             font_path = FONTS[font_family_name][font_style_name]
         except KeyError:
             raise LookupError("Couln't find the font & style")
         return font_path
 
-    context['font_path'] = get_font_path(context['font_family'], context['font_style'])
+    context["font_path"] = get_font_path(context["font_family"], context["font_style"])
 
     def get_label_dimensions(label_size):
         try:
-            ls = label_type_specs[context['label_size']]
+            ls = label_type_specs[context["label_size"]]
         except KeyError:
             raise LookupError("Unknown label_size")
-        return ls['dots_printable']
+        return ls["dots_printable"]
 
-    width, height = get_label_dimensions(context['label_size'])
-    if height > width: width, height = height, width
-    if context['orientation'] == 'rotated': height, width = width, height
-    context['width'], context['height'] = width, height
+    width, height = get_label_dimensions(context["label_size"])
+    if height > width:
+        width, height = height, width
+    if context["orientation"] == "rotated":
+        height, width = width, height
+    context["width"], context["height"] = width, height
 
     return context
 
+
 def create_label_im(text, **kwargs):
-    label_type = kwargs['kind']
-    im_font = ImageFont.truetype(kwargs['font_path'], kwargs['font_size'])
-    im = Image.new('L', (20, 20), 'white')
+    label_type = kwargs["kind"]
+    im_font = ImageFont.truetype(kwargs["font_path"], kwargs["font_size"])
+    im = Image.new("L", (20, 20), "white")
     draw = ImageDraw.Draw(im)
     # workaround for a bug in multiline_textsize()
     # when there are empty lines in the text:
     lines = []
-    for line in text.split('\n'):
-        if line == '': line = ' '
+    for line in text.split("\n"):
+        if line == "":
+            line = " "
         lines.append(line)
-    text = '\n'.join(lines)
+    text = "\n".join(lines)
     linesize = im_font.getsize(text)
     textsize = draw.multiline_textsize(text, font=im_font)
-    width, height = kwargs['width'], kwargs['height']
-    if kwargs['orientation'] == 'standard':
+    width, height = kwargs["width"], kwargs["height"]
+    if kwargs["orientation"] == "standard":
         if label_type in (ENDLESS_LABEL,):
-            height = textsize[1] + kwargs['margin_top'] + kwargs['margin_bottom']
-    elif kwargs['orientation'] == 'rotated':
+            height = textsize[1] + kwargs["margin_top"] + kwargs["margin_bottom"]
+    elif kwargs["orientation"] == "rotated":
         if label_type in (ENDLESS_LABEL,):
-            width = textsize[0] + kwargs['margin_left'] + kwargs['margin_right']
-    im = Image.new('RGB', (width, height), 'white')
+            width = textsize[0] + kwargs["margin_left"] + kwargs["margin_right"]
+    im = Image.new("RGB", (width, height), "white")
     draw = ImageDraw.Draw(im)
-    if kwargs['orientation'] == 'standard':
+    if kwargs["orientation"] == "standard":
         if label_type in (DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL):
-            vertical_offset  = (height - textsize[1])//2
-            vertical_offset += (kwargs['margin_top'] - kwargs['margin_bottom'])//2
+            vertical_offset = (height - textsize[1]) // 2
+            vertical_offset += (kwargs["margin_top"] - kwargs["margin_bottom"]) // 2
         else:
-            vertical_offset = kwargs['margin_top']
-        horizontal_offset = max((width - textsize[0])//2, 0)
-    elif kwargs['orientation'] == 'rotated':
-        vertical_offset  = (height - textsize[1])//2
-        vertical_offset += (kwargs['margin_top'] - kwargs['margin_bottom'])//2
+            vertical_offset = kwargs["margin_top"]
+        horizontal_offset = max((width - textsize[0]) // 2, 0)
+    elif kwargs["orientation"] == "rotated":
+        vertical_offset = (height - textsize[1]) // 2
+        vertical_offset += (kwargs["margin_top"] - kwargs["margin_bottom"]) // 2
         if label_type in (DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL):
-            horizontal_offset = max((width - textsize[0])//2, 0)
+            horizontal_offset = max((width - textsize[0]) // 2, 0)
         else:
-            horizontal_offset = kwargs['margin_left']
+            horizontal_offset = kwargs["margin_left"]
     offset = horizontal_offset, vertical_offset
-    draw.multiline_text(offset, text, kwargs['fill_color'], font=im_font, align=kwargs['align'])
+    draw.multiline_text(
+        offset, text, kwargs["fill_color"], font=im_font, align=kwargs["align"]
+    )
     return im
+
 
 def create_label_grocy(text, **kwargs):
-    product = kwargs['product']
-    duedate = kwargs['duedate']
-    grocycode = kwargs['grocycode']
-
+    product = kwargs["product"]
+    duedate = kwargs["duedate"]
+    grocycode = kwargs["grocycode"]
 
     # prepare grocycode datamatrix
-    from pylibdmtx.pylibdmtx import encode
-    encoded = encode(grocycode.encode('utf8'), size="SquareAuto") # adjusted for 300x300 dpi - results in DM code roughly 5x5mm
-    datamatrix = Image.frombytes('RGB', (encoded.width, encoded.height), encoded.pixels)
-    datamatrix.save('/tmp/dmtx.png')
+    encoded = encode(
+        grocycode.encode("utf8"), size="52x52"
+    )  # adjusted for 300x300 dpi - results in DM code roughly 5x5mm
+    datamatrix = Image.frombytes("RGB", (encoded.width, encoded.height), encoded.pixels)
 
-    product_font = ImageFont.truetype(kwargs['font_path'], 100)
-    duedate_font = ImageFont.truetype(kwargs['font_path'], 60)
-    width = kwargs['width']
-    height = 200
-    if kwargs['orientation'] == 'rotated':
-        tw = width
-        width = height
-        height = tw
+    product_font = ImageFont.truetype(kwargs["font_path"], 80)
+    best_by_font = ImageFont.truetype(kwargs["font_path"], 40)
+    code_font = ImageFont.truetype(kwargs["font_path"], 30)
 
-    im = Image.new('RGB', (width, height), 'white')
+    width = kwargs["width"]
+    height = encoded.height + kwargs["margin_bottom"]
+
+    im = Image.new("RGB", (width, height), "white")
     draw = ImageDraw.Draw(im)
-    if kwargs['orientation'] == 'standard':
-        vertical_offset = kwargs['margin_top']
-        horizontal_offset = kwargs['margin_left']
-    elif kwargs['orientation'] == 'rotated':
-        vertical_offset = kwargs['margin_top']
-        horizontal_offset = kwargs['margin_left']
-        datamatrix.transpose(Image.ROTATE_270)
 
-    im.paste(datamatrix, (horizontal_offset, vertical_offset, horizontal_offset + encoded.width, vertical_offset + encoded.height))
-
-    if kwargs['orientation'] == 'standard':
-        vertical_offset += -10
-        horizontal_offset = encoded.width + 40
-    elif kwargs['orientation'] == 'rotated':
-        vertical_offset += encoded.width + 40
-        horizontal_offset += -10
-
+    vertical_offset = kwargs["margin_top"]
+    horizontal_offset = kwargs["margin_left"]
     textoffset = horizontal_offset, vertical_offset
 
-    draw.text(textoffset, product, kwargs['fill_color'], font=product_font)
+    producttext = " ".join(product.split("\n")).strip()
+    lines = []
+    while len(producttext) > 0:
+        for i in range(len(producttext), 1, -1):
+            subtext = producttext[0:i]
+            if draw.textlength(subtext, font=product_font) < (
+                width - kwargs["margin_right"]
+            ):
+                lines.append(subtext)
+                producttext = producttext[i:].strip()
+                break
 
-    if duedate is not None:
-        if kwargs['orientation'] == 'standard':
-            vertical_offset += 110
-            horizontal_offset = kwargs['margin_left']
-        elif kwargs['orientation'] == 'rotated':
-            vertical_offset = kwargs['margin_left']
-            horizontal_offset += 110
-        textoffset = horizontal_offset, vertical_offset
+    title_text = "\n".join(lines)
+    grocycode_text = grocycode
+    best_by_text = duedate
 
-        draw.text(textoffset, duedate, kwargs['fill_color'], font=duedate_font)
+    title_textsize = draw.multiline_textsize(title_text, font=product_font)
+    grocycode_textsize = draw.textsize(
+        grocycode_text, font=code_font
+    )
+    best_by_textsize = draw.textsize(
+        best_by_text, font=best_by_font
+    )
+
+    # Increase the size of the image to accomodate the text
+    height = kwargs['margin_top'] + title_textsize[1] + grocycode_textsize[1] + encoded.height + kwargs['margin_bottom']
+    newim = Image.new('RGB', (width, height), 'white')
+    draw = ImageDraw.Draw(newim)
+    newim.paste(im)
+    im = newim
+
+    draw.multiline_text(textoffset, title_text, kwargs["fill_color"], font=product_font)
+    vertical_offset = vertical_offset + title_textsize[1]
+    textoffset = horizontal_offset, vertical_offset
+
+    # Draw the barcode and "best by" next to it
+    im.paste(
+        datamatrix,
+        (
+            horizontal_offset,
+            vertical_offset,
+            horizontal_offset + encoded.width,
+            vertical_offset + encoded.height,
+        ),
+    )
+    draw.multiline_text((horizontal_offset + encoded.width, vertical_offset), f"Best By:\n{duedate}", kwargs['fill_color'], font=best_by_font)
+    vertical_offset = vertical_offset + encoded.height
+    textoffset = horizontal_offset, vertical_offset
+
+    draw.text(textoffset, f"{grocycode}", kwargs['fill_color'], font=code_font)
 
     return im
 
-@get('/api/preview/text')
-@post('/api/preview/text')
+
+@get("/api/preview/text")
+@post("/api/preview/text")
 def get_preview_image():
     context = get_label_context(request)
     im = create_label_im(**context)
-    return_format = request.query.get('return_format', 'png')
-    if return_format == 'base64':
+    return_format = request.query.get("return_format", "png")
+    if return_format == "base64":
         import base64
-        response.set_header('Content-type', 'text/plain')
+
+        response.set_header("Content-type", "text/plain")
         return base64.b64encode(image_to_png_bytes(im))
     else:
-        response.set_header('Content-type', 'image/png')
+        response.set_header("Content-type", "image/png")
         return image_to_png_bytes(im)
+
 
 def image_to_png_bytes(im):
     image_buffer = BytesIO()
@@ -225,8 +272,9 @@ def image_to_png_bytes(im):
     image_buffer.seek(0)
     return image_buffer.read()
 
-@post('/api/print/grocy')
-@get('/api/print/grocy')
+
+@post("/api/print/grocy")
+@get("/api/print/grocy")
 def print_grocy():
     """
     API endpoint to consume the grocy label webhook.
@@ -234,49 +282,63 @@ def print_grocy():
     returns; JSON
     """
 
-    return_dict = {'success' : False }
+    return_dict = {"success": False}
 
     try:
         context = get_label_context(request)
     except LookupError as e:
-        return_dict['error'] = e.msg
+        return_dict["error"] = e.msg
         return return_dict
 
-    if context['product'] is None:
-        return_dict['error'] = 'Please provide the product for the label'
+    if context["product"] is None:
+        return_dict["error"] = "Please provide the product for the label"
         return return_dict
 
     im = create_label_grocy(**context)
-    if DEBUG: im.save('sample-out.png')
+    if DEBUG:
+        im.save("sample-out.png")
 
-    if context['kind'] == ENDLESS_LABEL:
-        rotate = 0 if context['orientation'] == 'standard' else 90
-    elif context['kind'] in (ROUND_DIE_CUT_LABEL, DIE_CUT_LABEL):
-        rotate = 'auto'
+    if context["kind"] == ENDLESS_LABEL:
+        rotate = 0 if context["orientation"] == "standard" else 90
+    elif context["kind"] in (ROUND_DIE_CUT_LABEL, DIE_CUT_LABEL):
+        rotate = "auto"
 
-    qlr = BrotherQLRaster(CONFIG['PRINTER']['MODEL'])
+    qlr = BrotherQLRaster(CONFIG["PRINTER"]["MODEL"])
     red = False
-    if 'red' in context['label_size']:
+    if "red" in context["label_size"]:
         red = True
-    create_label(qlr, im, context['label_size'], red=red, threshold=context['threshold'], cut=True, rotate=rotate)
+    create_label(
+        qlr,
+        im,
+        context["label_size"],
+        red=red,
+        threshold=context["threshold"],
+        cut=True,
+        rotate=rotate,
+    )
+
+    response.set_header("Content-type", "image/png")
+    return image_to_png_bytes(im)
 
     if not DEBUG:
         try:
-            be = BACKEND_CLASS(CONFIG['PRINTER']['PRINTER'])
+            be = BACKEND_CLASS(CONFIG["PRINTER"]["PRINTER"])
             be.write(qlr.data)
             be.dispose()
             del be
         except Exception as e:
-            return_dict['message'] = str(e)
-            logger.warning('Exception happened: %s', e)
+            return_dict["message"] = str(e)
+            logger.warning("Exception happened: %s", e)
             return return_dict
 
-    return_dict['success'] = True
-    if DEBUG: return_dict['data'] = str(qlr.data)
+    return_dict["success"] = True
+    if DEBUG:
+        return_dict["data"] = str(qlr.data)
     return return_dict
 
-@post('/api/print/text')
-@get('/api/print/text')
+
+@post("/api/print/text")
+@get("/api/print/text")
 def print_text():
     """
     API to print a label
@@ -287,126 +349,174 @@ def print_text():
     - alignment
     """
 
-    return_dict = {'success': False}
+    return_dict = {"success": False}
 
     try:
         context = get_label_context(request)
     except LookupError as e:
-        return_dict['error'] = e.msg
+        return_dict["error"] = e.msg
         return return_dict
 
-    if context['text'] is None:
-        return_dict['error'] = 'Please provide the text for the label'
+    if context["text"] is None:
+        return_dict["error"] = "Please provide the text for the label"
         return return_dict
 
     im = create_label_im(**context)
-    if DEBUG: im.save('sample-out.png')
+    if DEBUG:
+        im.save("sample-out.png")
 
-    if context['kind'] == ENDLESS_LABEL:
-        rotate = 0 if context['orientation'] == 'standard' else 90
-    elif context['kind'] in (ROUND_DIE_CUT_LABEL, DIE_CUT_LABEL):
-        rotate = 'auto'
+    if context["kind"] == ENDLESS_LABEL:
+        rotate = 0 if context["orientation"] == "standard" else 90
+    elif context["kind"] in (ROUND_DIE_CUT_LABEL, DIE_CUT_LABEL):
+        rotate = "auto"
 
-    qlr = BrotherQLRaster(CONFIG['PRINTER']['MODEL'])
+    qlr = BrotherQLRaster(CONFIG["PRINTER"]["MODEL"])
     red = False
-    if 'red' in context['label_size']:
+    if "red" in context["label_size"]:
         red = True
-    create_label(qlr, im, context['label_size'], red=red, threshold=context['threshold'], cut=True, rotate=rotate)
+    create_label(
+        qlr,
+        im,
+        context["label_size"],
+        red=red,
+        threshold=context["threshold"],
+        cut=True,
+        rotate=rotate,
+    )
 
     if not DEBUG:
         try:
-            be = BACKEND_CLASS(CONFIG['PRINTER']['PRINTER'])
+            be = BACKEND_CLASS(CONFIG["PRINTER"]["PRINTER"])
             be.write(qlr.data)
             be.dispose()
             del be
         except Exception as e:
-            return_dict['message'] = str(e)
-            logger.warning('Exception happened: %s', e)
+            return_dict["message"] = str(e)
+            logger.warning("Exception happened: %s", e)
             return return_dict
 
-    return_dict['success'] = True
-    if DEBUG: return_dict['data'] = str(qlr.data)
+    return_dict["success"] = True
+    if DEBUG:
+        return_dict["data"] = str(qlr.data)
     return return_dict
+
 
 def main():
     global DEBUG, FONTS, BACKEND_CLASS, CONFIG
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--port', default=False)
-    parser.add_argument('--loglevel', type=lambda x: getattr(logging, x.upper()), default=False)
-    parser.add_argument('--font-folder', default=False, help='folder for additional .ttf/.otf fonts')
-    parser.add_argument('--default-label-size', default=False, help='Label size inserted in your printer. Defaults to 62.')
-    parser.add_argument('--default-orientation', default=False, choices=('standard', 'rotated'), help='Label orientation, defaults to "standard". To turn your text by 90°, state "rotated".')
-    parser.add_argument('--model', default=False, choices=models, help='The model of your printer (default: QL-500)')
-    parser.add_argument('printer',  nargs='?', default=False, help='String descriptor for the printer to use (like tcp://192.168.0.23:9100 or file:///dev/usb/lp0)')
+    parser.add_argument("--port", default=False)
+    parser.add_argument(
+        "--loglevel", type=lambda x: getattr(logging, x.upper()), default=False
+    )
+    parser.add_argument(
+        "--font-folder", default=False, help="folder for additional .ttf/.otf fonts"
+    )
+    parser.add_argument(
+        "--default-label-size",
+        default=False,
+        help="Label size inserted in your printer. Defaults to 62.",
+    )
+    parser.add_argument(
+        "--default-orientation",
+        default=False,
+        choices=("standard", "rotated"),
+        help='Label orientation, defaults to "standard". To turn your text by 90°, state "rotated".',
+    )
+    parser.add_argument(
+        "--model",
+        default=False,
+        choices=models,
+        help="The model of your printer (default: QL-500)",
+    )
+    parser.add_argument(
+        "printer",
+        nargs="?",
+        default=False,
+        help="String descriptor for the printer to use (like tcp://192.168.0.23:9100 or file:///dev/usb/lp0)",
+    )
     args = parser.parse_args()
 
     if args.printer:
-        CONFIG['PRINTER']['PRINTER'] = args.printer
+        CONFIG["PRINTER"]["PRINTER"] = args.printer
 
     if args.port:
         PORT = args.port
     else:
-        PORT = CONFIG['SERVER']['PORT']
+        PORT = CONFIG["SERVER"]["PORT"]
 
     if args.loglevel:
         LOGLEVEL = args.loglevel
     else:
-        LOGLEVEL = CONFIG['SERVER']['LOGLEVEL']
+        LOGLEVEL = CONFIG["SERVER"]["LOGLEVEL"]
 
-    if LOGLEVEL == 10: # "DEBUG"
+    if LOGLEVEL == 10:  # "DEBUG"
         DEBUG = True
     else:
         DEBUG = False
 
     if args.model:
-        CONFIG['PRINTER']['MODEL'] = args.model
+        CONFIG["PRINTER"]["MODEL"] = args.model
 
     if args.default_label_size:
-        CONFIG['LABEL']['DEFAULT_SIZE'] = args.default_label_size
+        CONFIG["LABEL"]["DEFAULT_SIZE"] = args.default_label_size
 
     if args.default_orientation:
-        CONFIG['LABEL']['DEFAULT_ORIENTATION'] = args.default_orientation
+        CONFIG["LABEL"]["DEFAULT_ORIENTATION"] = args.default_orientation
 
     if args.font_folder:
         ADDITIONAL_FONT_FOLDER = args.font_folder
     else:
-        ADDITIONAL_FONT_FOLDER = CONFIG['SERVER']['ADDITIONAL_FONT_FOLDER']
-
+        ADDITIONAL_FONT_FOLDER = CONFIG["SERVER"]["ADDITIONAL_FONT_FOLDER"]
 
     logging.basicConfig(level=LOGLEVEL)
 
     try:
-        selected_backend = guess_backend(CONFIG['PRINTER']['PRINTER'])
+        selected_backend = guess_backend(CONFIG["PRINTER"]["PRINTER"])
     except ValueError:
-        parser.error("Couln't guess the backend to use from the printer string descriptor")
-    BACKEND_CLASS = backend_factory(selected_backend)['backend_class']
+        parser.error(
+            "Couln't guess the backend to use from the printer string descriptor"
+        )
+    BACKEND_CLASS = backend_factory(selected_backend)["backend_class"]
 
-    if CONFIG['LABEL']['DEFAULT_SIZE'] not in label_sizes:
-        parser.error("Invalid --default-label-size. Please choose on of the following:\n:" + " ".join(label_sizes))
+    if CONFIG["LABEL"]["DEFAULT_SIZE"] not in label_sizes:
+        parser.error(
+            "Invalid --default-label-size. Please choose on of the following:\n:"
+            + " ".join(label_sizes)
+        )
 
     FONTS = get_fonts()
     if ADDITIONAL_FONT_FOLDER:
         FONTS.update(get_fonts(ADDITIONAL_FONT_FOLDER))
 
     if not FONTS:
-        sys.stderr.write("Not a single font was found on your system. Please install some or use the \"--font-folder\" argument.\n")
+        sys.stderr.write(
+            'Not a single font was found on your system. Please install some or use the "--font-folder" argument.\n'
+        )
         sys.exit(2)
 
-    for font in CONFIG['LABEL']['DEFAULT_FONTS']:
+    for font in CONFIG["LABEL"]["DEFAULT_FONTS"]:
         try:
-            FONTS[font['family']][font['style']]
-            CONFIG['LABEL']['DEFAULT_FONTS'] = font
+            FONTS[font["family"]][font["style"]]
+            CONFIG["LABEL"]["DEFAULT_FONTS"] = font
             logger.debug("Selected the following default font: {}".format(font))
             break
-        except: pass
-    if CONFIG['LABEL']['DEFAULT_FONTS'] is None:
-        sys.stderr.write('Could not find any of the default fonts. Choosing a random one.\n')
-        family =  random.choice(list(FONTS.keys()))
-        style =   random.choice(list(FONTS[family].keys()))
-        CONFIG['LABEL']['DEFAULT_FONTS'] = {'family': family, 'style': style}
-        sys.stderr.write('The default font is now set to: {family} ({style})\n'.format(**CONFIG['LABEL']['DEFAULT_FONTS']))
+        except:
+            pass
+    if CONFIG["LABEL"]["DEFAULT_FONTS"] is None:
+        sys.stderr.write(
+            "Could not find any of the default fonts. Choosing a random one.\n"
+        )
+        family = random.choice(list(FONTS.keys()))
+        style = random.choice(list(FONTS[family].keys()))
+        CONFIG["LABEL"]["DEFAULT_FONTS"] = {"family": family, "style": style}
+        sys.stderr.write(
+            "The default font is now set to: {family} ({style})\n".format(
+                **CONFIG["LABEL"]["DEFAULT_FONTS"]
+            )
+        )
 
-    run(host=CONFIG['SERVER']['HOST'], port=PORT, debug=DEBUG)
+    run(host=CONFIG["SERVER"]["HOST"], port=PORT, debug=DEBUG)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Sorry for this wacky PR, I don't really expect you to merge it, but I figured I'd send it anyway.

The bulk of the changes are from running `black`. If you autoformat your code I can rebase this on top and it'll be a lot smaller.

These changes print out a label like this:

![image](https://user-images.githubusercontent.com/76716/147858306-052ade5c-eea6-41d5-837d-7c547a08fe22.png)

I added the grocycode printed in text as a backup. The larger datamatrix code seems a bit easier to read for my phone. I also deleted any support for rotating the label because it was complicated and I don't plan on using it.

Anyway, like I said, I don't really expect you to want it, but figured I'd PR it anyway.